### PR TITLE
Add options, fix display, make it closer to google keep

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ This is a companion card for [Google Keep sensor](https://github.com/PiotrMachow
 | `alpha` | `float` | `False` | 1 | Level of transparency used for notes (0 - fully transparent, 1 - not transparent) |
 | `show` | `list` | `True` | - | List of sections that should be displayed. Possible values: `checked`, `unchecked` |
 | `hide_if_empty` | `boolean` | `False` | `false` | Enables hiding cart when there are no notes found. Possible values: `true`, `false` |
-| `systemBox` | `boolean` | `False` | `false` | Make each note a HA tile instead of emcapsulate them into a HA tile |
-| `forceBackground` | `boolean` | `False` | `false` | Force the background to white/black according to the theme |
-| `smallTitleMargin` | `boolean` | `False` | `false` | Allow to reduce the bottom margin of the title even further |
+| `system_box` | `boolean` | `False` | `false` | Make each note a HA tile instead of encapsulating them into a HA tile |
+| `force_background` | `boolean` | `False` | `false` | Force the background to white/black according to the theme |
+| `small_title_margin` | `boolean` | `False` | `false` | Reduce the bottom margin of the title |
 
 ## Example usage:
 ```yaml
@@ -39,18 +39,29 @@ views:
 ```
 
 ## Installation
+### Manual
 1. Download [*google-keep-card.js*](https://github.com/PiotrMachowski/Lovelace-Google-Keep-card/raw/master/dist/google-keep-card.js) to `/www/custom_lovelace/google_keep_card` directory:
     ```bash
     mkdir -p www/custom_lovelace/google_keep_card
     cd www/custom_lovelace/google_keep_card/
     wget https://github.com/PiotrMachowski/Lovelace-Google-Keep-card/raw/master/dist/google-keep-card.js
     ```
-2. Add card to resources in `ui-lovelace.yaml` or in raw editor if you are using frontend UI editor:
+2. Add card to resources:
     ```yaml
     resources:
       - url: /local/custom_lovelace/google_keep_card/google-keep-card.js
         type: module
     ```
+
+### HACS
+1. Find this card in "Frontend" section and install it 
+2. Add card to resources:
+    ```yaml
+    resources:
+      - url: /hacsfiles/google_keep_card/google-keep-card.js
+        type: module
+    ```
+
 ## FAQ
 * **Does this card allow editing notes?**
   

--- a/README.md
+++ b/README.md
@@ -16,11 +16,13 @@ This is a companion card for [Google Keep sensor](https://github.com/PiotrMachow
 | --- | --- | --- | --- | --- |
 | `title` | `string` | `False` | - | Desired title of a card |
 | `entity` | `string` | `True` | - | ID of Google Keep sensor |
-| `theme` | `string` | `False` | `light` | Theme to be used for notes. Possible values: `light`, `dark` |
+| `theme` | `string` | `False` | `light` | Theme to be used for notes. Possible values: `light`, `dark`, `auto` |
 | `alpha` | `float` | `False` | 1 | Level of transparency used for notes (0 - fully transparent, 1 - not transparent) |
 | `show` | `list` | `True` | - | List of sections that should be displayed. Possible values: `checked`, `unchecked` |
 | `hide_if_empty` | `boolean` | `False` | `false` | Enables hiding cart when there are no notes found. Possible values: `true`, `false` |
-
+| `systemBox` | `boolean` | `False` | `false` | Make each note a HA tile instead of emcapsulate them into a HA tile |
+| `forceBackground` | `boolean` | `False` | `false` | Force the background to white/black according to the theme |
+| `smallTitleMargin` | `boolean` | `False` | `false` | Allow to reduce the bottom margin of the title even further |
 
 ## Example usage:
 ```yaml

--- a/dist/google-keep-card.js
+++ b/dist/google-keep-card.js
@@ -41,9 +41,9 @@ class GoogleKeepCard extends LitElement {
         }
         this._theme = config.theme || 'auto';
         this._alpha = config.alpha || 1;
-        this._systemBox = !!config.systemBox;
-        this._forceBackground = !!config.forceBackground;
-        this._smallTitleMargin = !!config.smallTitleMargin;
+        this._systemBox = !!config.system_box;
+        this._forceBackground = !!config.force_background;
+        this._smallTitleMargin = !!config.small_title_margin;
         this._config = config;
     }
 
@@ -67,11 +67,10 @@ class GoogleKeepCard extends LitElement {
         if (!notes.length && this._config.hide_if_empty) {
             return html``;
         }
-        // style="padding: 8px 0 16px 0;"
-        const title = this._config.title && !this._systemBox ? html`<h1 class="card-header ${this._smallTitleMargin && 'smallTitleMargin'}"><div class="name">${this._config.title}</div></div>` : html``;
+        const title = this._config.title && !this._systemBox ? html`<h1 class="card-header${this._smallTitleMargin ? ' smallTitleMargin' : ''}"><div class="name">${this._config.title}</div></div>` : html``;
         const emptyScreen = notes.length ? html`` : html`<p style="text-align: center">No notes found!</p>`;
         return html`
-        <ha-card id="googleKeepCard" class="${this._theme == 'auto'? (this._hass.themes.darkMode ? 'dark' : 'light') : this._theme} ${this._systemBox && 'systemBox'} ${this._forceBackground && 'forceBackground'}">
+        <ha-card id="googleKeepCard" class="${this._theme === 'auto' ? (this._hass.themes.darkMode ? 'dark' : 'light') : this._theme}${this._systemBox ? ' systemBox' : ''}${this._forceBackground ? ' forceBackground' : ''}">
             <style>
                 #googleKeepCard .content {
                     padding: 0 16px 16px;
@@ -83,33 +82,29 @@ class GoogleKeepCard extends LitElement {
                     margin: 0px;
                     padding: 0px;
                 }
-                
                 #googleKeepCard .smallTitleMargin {
                     padding-bottom: 4px;
-                }
-                    
+                }   
                 #googleKeepCard .card  {
                     margin: 16px 0px;
                     padding: 12px 16px;
                     position: relative;
                     overflow-wrap: break-word;
+                    opacity: ${this._alpha};
                 }
-                
                 #googleKeepCard.systemBox .card  {
-                    margin: var( --vertical-stack-card-margin, var(--stack-card-margin, 8px 0) );
+                    margin: var(--vertical-stack-card-margin, var(--stack-card-margin, 8px 0) );
                 }
                 #googleKeepCard.systemBox .card::before  {
                     border-radius: var(--ha-card-border-radius, 4px);
                     box-shadow: var( --ha-card-box-shadow, 0px 2px 1px -1px rgba(0, 0, 0, 0.2), 0px 1px 1px 0px rgba(0, 0, 0, 0.14), 0px 1px 3px 0px rgba(0, 0, 0, 0.12) );
-                }
-                    
+                }   
                 #googleKeepCard .card:first-of-type {
                     margin-top: 0;
                 }
                 #googleKeepCard .card:last-of-type {
                     margin-bottom: 0;
                 }
-                
                 #googleKeepCard .card::before{
                     content: '';
                     display: block;
@@ -120,36 +115,36 @@ class GoogleKeepCard extends LitElement {
                     bottom:0;
                     left: 0;
                     right: 0;
-                    opacity: ${this._alpha};
                 }
                 #googleKeepCard .card > * {
                     position: relative;
                 }
-                
                 #googleKeepCard .noteTitle {
                     font-weight: bold;
                     margin: 0 0 14px 0;
                     font-size: 120%;
                 }
-                
                 #googleKeepCard .noteLine  {
                     margin-top: 6px;
                     margin-bottom: 6px;
                     min-height: 20px;
                 }
-                
                 #googleKeepCard hr {
                     margin: 10px 0;
-                    border: 1px solid rgba(0,0,0,0.1);
+                    border: 1px solid;
                 }
-                
+                #googleKeepCard.dark hr {
+                    border-color: #e8eaed;
+                }
+                #googleKeepCard.light hr {
+                    border-color: #202124;
+                }
                 #googleKeepCard.forceBackground.dark {
                     background-color: #202124;
                 }
-                #googleKeepCard.dark, #googleKeepCard.dark a, #googleKeepCard.dark a:visited, #googleKeepCard.dark a:link {
+                #googleKeepCard.dark .content, #googleKeepCard.dark a, #googleKeepCard.dark a:visited, #googleKeepCard.dark a:link {
                     color: #e8eaed;
                 }
-                
                 #googleKeepCard.dark .card.White::before {
                     background-color: #202124;
                     border-color: #5f6368;
@@ -161,7 +156,6 @@ class GoogleKeepCard extends LitElement {
                 #googleKeepCard.dark .card.Orange::before {
                     background-color: #614a19;
                     border-color: #614a19;
-                
                 }
                 #googleKeepCard.dark .card.Yellow::before {
                     background-color: #635d19;
@@ -194,18 +188,15 @@ class GoogleKeepCard extends LitElement {
                 #googleKeepCard.dark .card.Brown::before {
                     background-color: #442f19;
                     border-color: #442f19;
-                
                 }
                 #googleKeepCard.dark .card.Gray::before {
                     background-color: #3c3f43;
                     border-color: #3c3f43;
                 }
-                
                 #googleKeepCard.forceBackground.light {
                     background-color: #fff;
                 }
-                
-                #googleKeepCard.light, #googleKeepCard.light a, #googleKeepCard.light a:visited, #googleKeepCard.light a:link {
+                #googleKeepCard.light .content, #googleKeepCard.light a, #googleKeepCard.light a:visited, #googleKeepCard.light a:link {
                     color: #202124;
                 }
                 #googleKeepCard.light .card.White::before {
@@ -256,19 +247,12 @@ class GoogleKeepCard extends LitElement {
                     background-color: #e8eaed;
                     border-color: #e8eaed;
                 }
-
                 #googleKeepCard .checked {
                     color: #5f6368;
                 }
-                
                 #googleKeepCard .crossed {
                     text-decoration: line-through;
-                }
-                
-                #googleKeepCard .checked.uncrossed {
-                    opacity: .35;
-                }
-                
+                }               
                 #googleKeepCard .level-0 {
                     margin-left: 24px;
                 }
@@ -287,8 +271,7 @@ class GoogleKeepCard extends LitElement {
                     opacity: 0.54;
                     background-size: 18px 18px;
                     background-position: center;
-                    background-repeat: no-repeat;
-                    
+                    background-repeat: no-repeat;   
                 }
                 #googleKeepCard.dark .checked::before {
                     background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSIjZmZmZmZmIj48cGF0aCBkPSJNMTkgM0g1Yy0xLjEgMC0yIC45LTIgMnYxNGMwIDEuMS45IDIgMiAyaDE0YzEuMSAwIDItLjkgMi0yVjVjMC0xLjEtLjktMi0yLTJ6bTAgMTZINVY1aDE0djE0eiIvPgogIDxwYXRoIGQ9Ik0xOCA5bC0xLjQtMS40LTYuNiA2LjYtMi42LTIuNkw2IDEzbDQgNHoiLz4KPC9zdmc+Cg==);
@@ -302,7 +285,6 @@ class GoogleKeepCard extends LitElement {
                 #googleKeepCard.light .unchecked::before {
                     background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSIjMDAwIj4KICA8cGF0aCBkPSJNMTkgNXYxNEg1VjVoMTRtMC0ySDVjLTEuMSAwLTIgLjktMiAydjE0YzAgMS4xLjkgMiAyIDJoMTRjMS4xIDAgMi0uOSAyLTJWNWMwLTEuMS0uOS0yLTItMnoiLz4KPC9zdmc+Cg==); 
                 }
-            
             </style>
             ${title}
             ${emptyScreen}
@@ -349,7 +331,7 @@ class GoogleKeepCard extends LitElement {
         return html`${items.filter(
             c => checked ? (c.checked || c.children.some(cc => cc.checked)): !c.checked)
         .map(
-            item => html`${this.renderListNoteLine(item, checked, level)}${(item.children && item.children.length ? this.renderListNoteLines(item.children, checked, level + 1): '')}`
+            item => html`${this.renderListNoteLine(item, checked, level)}${(item.children && item.children.length ? this.renderListNoteLines(item.children, checked, level + 1) : '')}`
         )}`;
     }
 }

--- a/dist/google-keep-card.js
+++ b/dist/google-keep-card.js
@@ -90,7 +90,6 @@ class GoogleKeepCard extends LitElement {
                     padding: 12px 16px;
                     position: relative;
                     overflow-wrap: break-word;
-                    opacity: ${this._alpha};
                 }
                 #googleKeepCard.systemBox .card  {
                     margin: var(--vertical-stack-card-margin, var(--stack-card-margin, 8px 0) );
@@ -115,6 +114,7 @@ class GoogleKeepCard extends LitElement {
                     bottom:0;
                     left: 0;
                     right: 0;
+                    opacity: ${this._alpha};
                 }
                 #googleKeepCard .card > * {
                     position: relative;

--- a/dist/google-keep-card.js
+++ b/dist/google-keep-card.js
@@ -321,9 +321,9 @@ class GoogleKeepCard extends LitElement {
         const showChecked = note['checked'].length && show.includes('checked');
         console.log({result: this.renderList2(note), note});
         return html`
-    ${this.renderList2(note.children)}
+    ${showUnchecked ? this.renderList2(note.children) : html``}
     ${showUnchecked && showChecked ? html`<hr>` : html``}
-    ${this.renderList2(note.children, true)}
+    ${showChecked ? this.renderList2(note.children, true) : html``}
 `
     }
 

--- a/dist/google-keep-card.js
+++ b/dist/google-keep-card.js
@@ -42,6 +42,8 @@ class GoogleKeepCard extends LitElement {
         this._theme = config.theme || 'auto';
         this._alpha = config.alpha || 1;
         this._systemBox = !!config.systemBox;
+        this._forceBackground = !!config.forceBackground;
+        this._smallTitleMargin = !!config.smallTitleMargin;
         this._config = config;
     }
 
@@ -65,13 +67,14 @@ class GoogleKeepCard extends LitElement {
         if (!notes.length && this._config.hide_if_empty) {
             return html``;
         }
-        const title = this._config.title && !this._systemBox ? html`<div class="card-header" style="padding: 8px 0 16px 0;"><div class="name">${this._config.title}</div></div>` : html``;
+        // style="padding: 8px 0 16px 0;"
+        const title = this._config.title && !this._systemBox ? html`<h1 class="card-header ${this._smallTitleMargin && 'smallTitleMargin'}"><div class="name">${this._config.title}</div></div>` : html``;
         const emptyScreen = notes.length ? html`` : html`<p style="text-align: center">No notes found!</p>`;
         return html`
-        <ha-card id="googleKeepCard" class="${this._theme == 'auto'? (this._hass.themes.darkMode ? 'dark' : 'light') : this._theme} ${this._systemBox ? 'systemBox': ''}">
+        <ha-card id="googleKeepCard" class="${this._theme == 'auto'? (this._hass.themes.darkMode ? 'dark' : 'light') : this._theme} ${this._systemBox && 'systemBox'} ${this._forceBackground && 'forceBackground'}">
             <style>
-                #googleKeepCard {
-                    padding: 16px;
+                #googleKeepCard .content {
+                    padding: 0 16px 16px;
                 }
                 #googleKeepCard.systemBox {
                     background-color: transparent !important;
@@ -80,11 +83,16 @@ class GoogleKeepCard extends LitElement {
                     margin: 0px;
                     padding: 0px;
                 }
+                
+                #googleKeepCard .smallTitleMargin {
+                    padding-bottom: 4px;
+                }
                     
                 #googleKeepCard .card  {
                     margin: 16px 0px;
                     padding: 12px 16px;
                     position: relative;
+                    overflow-wrap: break-word;
                 }
                 
                 #googleKeepCard.systemBox .card  {
@@ -127,6 +135,7 @@ class GoogleKeepCard extends LitElement {
                 #googleKeepCard .noteLine  {
                     margin-top: 6px;
                     margin-bottom: 6px;
+                    min-height: 20px;
                 }
                 
                 #googleKeepCard hr {
@@ -134,7 +143,7 @@ class GoogleKeepCard extends LitElement {
                     border: 1px solid rgba(0,0,0,0.1);
                 }
                 
-                #googleKeepCard.dark {
+                #googleKeepCard.forceBackground.dark {
                     background-color: #202124;
                 }
                 #googleKeepCard.dark, #googleKeepCard.dark a, #googleKeepCard.dark a:visited, #googleKeepCard.dark a:link {
@@ -192,7 +201,7 @@ class GoogleKeepCard extends LitElement {
                     border-color: #3c3f43;
                 }
                 
-                #googleKeepCard.light {
+                #googleKeepCard.forceBackground.light {
                     background-color: #fff;
                 }
                 
@@ -297,7 +306,9 @@ class GoogleKeepCard extends LitElement {
             </style>
             ${title}
             ${emptyScreen}
-            ${notes.map(note => this.renderNote(note))}
+            <div class="content">
+                ${notes.map(note => this.renderNote(note))}
+            </div>
         </ha-card>
         `;
     }

--- a/dist/google-keep-card.js
+++ b/dist/google-keep-card.js
@@ -1,52 +1,9 @@
 var LitElement = LitElement || Object.getPrototypeOf(customElements.get("home-assistant-main"));
 var html = LitElement.prototype.html;
 
-const themeLight = "light";
-const themeDark = "dark";
 const themes = ['light', 'dark', 'auto'];
-const colors = {
-    'White': ['#ffffff', '#2d2e30'],
-    'Red': ['#f28b82', '#5c2b29'],
-    'Orange': ['#fbbc04', '#614a19'],
-    'Yellow': ['#fff475', '#635d19'],
-    'Green': ['#ccff90', '#345920'],
-    'Teal': ['#a7ffeb', '#16504b'],
-    'Blue': ['#cbf0f8', '#2d555e'],
-    'DarkBlue': ['#aecbfa', '#1e3a5f'],
-    'Purple': ['#d7aefb', '#42275e'],
-    'Pink': ['#fdcfe8', '#5b2245'],
-    'Brown': ['#e6c9a8', '#442f19'],
-    'Gray': ['#e8eaed', '#3c3f43'],
-};
-const textColors = {
-    "light": "#000000",
-    "dark": "#ffffff"
-};
-const checkedColors = {
-    "light": "rgb(95, 99, 104)",
-    "dark": "rgb(154,160,166)"
-};
 
 class GoogleKeepCard extends LitElement {
-
-    getColor(colorName) {
-        const hex = colors[colorName][themes.indexOf(this._theme)];
-        const {r, g, b} = GoogleKeepCard.hexToRgb(hex);
-        return `rgba(${r}, ${g}, ${b}, ${this._alpha})`;
-    }
-    addAlphaToColor(hexColor) {
-        const {r, g, b} = GoogleKeepCard.hexToRgb(hexColor);
-        return `rgba(${r}, ${g}, ${b}, ${this._alpha})`;
-    }
-
-    getTextColor() {
-        return textColors[this._theme];
-    }
-
-    getCheckedColor() {
-        return checkedColors[this._theme];
-    }
-
     constructor() {
         super();
     }
@@ -60,6 +17,9 @@ class GoogleKeepCard extends LitElement {
 
     set hass(hass) {
         this._hass = hass;
+    }
+    get hass(hass) {
+        return this._hass;
     }
 
     setConfig(config) {
@@ -110,10 +70,31 @@ class GoogleKeepCard extends LitElement {
         <ha-card id="googleKeepCard" style="padding: 16px" class="${this._theme == 'auto'? (this._hass.themes.darkMode ? 'dark' : 'light') : this._theme}">
             <style>
                 #googleKeepCard .card  {
-                    border: 1px solid transparent;
-                    border-radius: 8px;
                     margin: 16px 0px;
                     padding: 12px 16px;
+                    position: relative;
+                }
+                #googleKeepCard .card:first-of-type {
+                    margin-top: 0;
+                }
+                #googleKeepCard .card:last-of-type {
+                    margin-bottom: 0;
+                }
+                
+                #googleKeepCard .card::before{
+                    content: '';
+                    display: block;
+                    position: absolute;
+                    border: 1px solid transparent;
+                    border-radius: 8px;
+                    top: 0;
+                    bottom:0;
+                    left: 0;
+                    right: 0;
+                    opacity: ${this._alpha};
+                }
+                #googleKeepCard .card > * {
+                    position: relative;
                 }
                 
                 #googleKeepCard .noteTitle {
@@ -139,53 +120,53 @@ class GoogleKeepCard extends LitElement {
                     color: #e8eaed;
                 }
                 
-                #googleKeepCard.dark .card.White {
+                #googleKeepCard.dark .card.White::before {
                     background-color: #202124;
                     border-color: #5f6368;
                 }
-                #googleKeepCard.dark .card.Red {
+                #googleKeepCard.dark .card.Red::before {
                     background-color: #5c2b29;
                     border-color: #5c2b29;
                 }
-                #googleKeepCard.dark .card.Orange {
+                #googleKeepCard.dark .card.Orange::before {
                     background-color: #614a19;
                     border-color: #614a19;
                 
                 }
-                #googleKeepCard.dark .card.Yellow {
+                #googleKeepCard.dark .card.Yellow::before {
                     background-color: #635d19;
                     border-color: #635d19;
                 }
-                #googleKeepCard.dark .card.Green {
+                #googleKeepCard.dark .card.Green::before {
                     background-color: #345920;
                     border-color: #345920;
                 }
-                #googleKeepCard.dark .card.Teal {
+                #googleKeepCard.dark .card.Teal::before {
                     background-color: #16504b;
                     border-color: #16504b;
                 }
-                #googleKeepCard.dark .card.Blue {
+                #googleKeepCard.dark .card.Blue::before {
                     background-color: #2d555e;
                     border-color: #2d555e;
                 }
-                #googleKeepCard.dark .card.DarkBlue {
+                #googleKeepCard.dark .card.DarkBlue::before {
                     background-color: #1e3a5f;
                     border-color: #1e3a5f;
                 }
-                #googleKeepCard.dark .card.Purple {
+                #googleKeepCard.dark .card.Purple::before {
                     background-color: #42275e;
                     border-color: #42275e;
                 }
-                #googleKeepCard.dark .card.Pink {
+                #googleKeepCard.dark .card.Pink::before {
                     background-color: #5b2245;
                     border-color: #5b2245;
                 }
-                #googleKeepCard.dark .card.Brown {
+                #googleKeepCard.dark .card.Brown::before {
                     background-color: #442f19;
                     border-color: #442f19;
                 
                 }
-                #googleKeepCard.dark .card.Gray {
+                #googleKeepCard.dark .card.Gray::before {
                     background-color: #3c3f43;
                     border-color: #3c3f43;
                 }
@@ -197,51 +178,51 @@ class GoogleKeepCard extends LitElement {
                 #googleKeepCard.light, #googleKeepCard.light a, #googleKeepCard.light a:visited, #googleKeepCard.light a:link {
                     color: #202124;
                 }
-                #googleKeepCard.light .card.White {
+                #googleKeepCard.light .card.White::before {
                     background-color: #fff;
                     border-color: #e0e0e0;
                 }
-                #googleKeepCard.light .card.Red {
+                #googleKeepCard.light .card.Red::before {
                     background-color: #f28b82;
                     border-color: #f28b82;
                 }
-                #googleKeepCard.light .card.Orange {
+                #googleKeepCard.light .card.Orange::before {
                     background-color: #fbbc04;
                     border-color: #fbbc04;
                 }
-                #googleKeepCard.light .card.Yellow {
+                #googleKeepCard.light .card.Yellow::before {
                     background-color: #fff475;
                     border-color: #fff475;
                 }
-                #googleKeepCard.light .card.Green {
+                #googleKeepCard.light .card.Green::before {
                     background-color: #ccff90;
                     border-color: #ccff90;
                 }
-                #googleKeepCard.light .card.Teal {
+                #googleKeepCard.light .card.Teal::before {
                     background-color: #a7ffeb;
                     border-color: #a7ffeb;
                 }
-                #googleKeepCard.light .card.Blue {
+                #googleKeepCard.light .card.Blue::before {
                     background-color: #cbf0f8;
                     border-color: #cbf0f8;
                 }
-                #googleKeepCard.light .card.DarkBlue {
+                #googleKeepCard.light .card.DarkBlue::before {
                     background-color: #aecbfa;
                     border-color: #aecbfa;
                 }
-                #googleKeepCard.light .card.Purple {
+                #googleKeepCard.light .card.Purple::before {
                     background-color: #d7aefb;
                     border-color: #d7aefb;
                 }
-                #googleKeepCard.light .card.Pink {
+                #googleKeepCard.light .card.Pink::before {
                     background-color: #fdcfe8;
                     border-color: #fdcfe8;
                 }
-                #googleKeepCard.light .card.Brown {
+                #googleKeepCard.light .card.Brown::before {
                     background-color: #e6c9a8;
                     border-color: #e6c9a8;
                 }
-                #googleKeepCard.light .card.Gray {
+                #googleKeepCard.light .card.Gray::before {
                     background-color: #e8eaed;
                     border-color: #e8eaed;
                 }
@@ -301,89 +282,43 @@ class GoogleKeepCard extends LitElement {
     }
 
     renderNote(note) {
-        console.log(note.note_type, {note});
         return html`
-<div class="card ${note['color']}">
-    <p class="noteTitle">${(typeof note['url']!= "undefined") ? html`<a target="_blank" href="${note['url']}">${note['title']}</a>` : html`${note['title']}` }</p>
-    ${note.note_type === 'NodeType.List' ? this.renderList(note) : this.renderTextNote(note)}
-</div>`
+<div class="card ${note.color}">
+    <p class="noteTitle">${(typeof note.url != "undefined") ? html`<a target="_blank" href="${note.url}">${note.title}</a>` : html`${note.title}` }</p>
+    ${note.note_type === 'NodeType.List' ? this.renderListNote(note) : this.renderTextNote(note)}
+</div>`;
     }
 
     renderTextNote(note) {
         return html`
-    <p class="noteBody">${note['lines'].map(line => this.renderLine(line))}</p>
-`
+    <p class="noteBody">${note.lines.map(line => html`<div class="noteLine">${line}</br></div>`)}</p>
+`;
     }
 
-    renderList(note) {
+    renderListNote(note) {
         const {show} = this._config;
-        const showUnchecked = note['unchecked'].length && show.includes('unchecked');
-        const showChecked = note['checked'].length && show.includes('checked');
-        console.log({result: this.renderList2(note), note});
+        const showUnchecked = note.unchecked.length && show.includes('unchecked');
+        const showChecked = note.checked.length && show.includes('checked');
         return html`
-    ${showUnchecked ? this.renderList2(note.children) : html``}
+    ${showUnchecked ? this.renderListNoteLines(note.children) : html``}
     ${showUnchecked && showChecked ? html`<hr>` : html``}
-    ${showChecked ? this.renderList2(note.children, true) : html``}
-`
+    ${showChecked ? this.renderListNoteLines(note.children, true) : html``}
+`;
     }
 
-    renderLine2(item, checked = false, level = 0) {
+    renderListNoteLine(item, checked = false, level = 0) {
         return html`<p class="noteLine ${checked? 'checked' : 'unchecked'} ${item.checked ? 'crossed' : 'uncrossed'} level-${level}">${item.text}</p>`;
     }
 
-    renderList2(items, checked = false, level = 0) {
-        console.log(level, {items, checked, level});
-        if (!items?.length) {
+    renderListNoteLines(items, checked = false, level = 0) {
+        if (!items || !items.length) {
             return html``;
         }
-        return html`${items?.filter(
+        return html`${items.filter(
             c => checked ? (c.checked || c.children.some(cc => cc.checked)): !c.checked)
         .map(
-            item => html`${this.renderLine2(item, checked, level)}${(item.children?.length ? this.renderList2(item.children, checked, level +1): '')}`
+            item => html`${this.renderListNoteLine(item, checked, level)}${(item.children && item.children.length ? this.renderListNoteLines(item.children, checked, level + 1): '')}`
         )}`;
-    }
-
-    renderUncheckedList(note) {
-        return html`<p class="noteBody uncheck">${note['unchecked'].map(line => this.renderLine(line))}</p>`;
-    }
-
-    renderCheckedList(note) {
-        return html`<p class="noteBody checked">${note['children'].map(line => this.renderIfChecked(line))}</p>`;
-    }
-
-    renderIfChecked(child) {
-        let checkedChildren = child.children.filter(c => c.checked);
-        if (child.checked || checkedChildren.length > 0) {
-            return html`${this.renderLine('\u2611' + child.text, child.checked)}${checkedChildren.map(c => this.renderLine('  ' + '\u2611' + c.text, true))}`;
-        }
-        return html``;
-    }
-
-    renderLine(line, strikethrough = false) {
-        let trimmed = line.replace(/^ +/, '');
-        let trimmedLength = trimmed.length;
-        if (trimmedLength > 0) {
-            let prefix = '\xa0'.repeat((line.length - trimmedLength) * 2);
-            let suffix = trimmed.substr(1);
-            if (strikethrough) {
-                suffix = html`<s>${suffix}</s>`
-            }
-            if (trimmed[0] === '\u2610') {
-                trimmed = html`${prefix}<paper-checkbox>${suffix}</paper-checkbox>`;
-            } else if (trimmed[0] === '\u2611') {
-                trimmed = html`${prefix}<paper-checkbox checked>${suffix}</paper-checkbox>`;
-            }
-        }
-        return html`<div class="noteLine">${trimmed}</br></div>`;
-    }
-
-    static hexToRgb(hex) {
-        let result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-        return result ? {
-            r: parseInt(result[1], 16),
-            g: parseInt(result[2], 16),
-            b: parseInt(result[3], 16)
-        } : null;
     }
 }
 

--- a/dist/google-keep-card.js
+++ b/dist/google-keep-card.js
@@ -3,7 +3,7 @@ var html = LitElement.prototype.html;
 
 const themeLight = "light";
 const themeDark = "dark";
-const themes = [themeLight, themeDark];
+const themes = ['light', 'dark', 'auto'];
 const colors = {
     'White': ['#ffffff', '#2d2e30'],
     'Red': ['#f28b82', '#5c2b29'],
@@ -16,7 +16,7 @@ const colors = {
     'Purple': ['#d7aefb', '#42275e'],
     'Pink': ['#fdcfe8', '#5b2245'],
     'Brown': ['#e6c9a8', '#442f19'],
-    'Grey': ['#e8eaed', '#3c3f43'],
+    'Gray': ['#e8eaed', '#3c3f43'],
 };
 const textColors = {
     "light": "#000000",
@@ -32,6 +32,10 @@ class GoogleKeepCard extends LitElement {
     getColor(colorName) {
         const hex = colors[colorName][themes.indexOf(this._theme)];
         const {r, g, b} = GoogleKeepCard.hexToRgb(hex);
+        return `rgba(${r}, ${g}, ${b}, ${this._alpha})`;
+    }
+    addAlphaToColor(hexColor) {
+        const {r, g, b} = GoogleKeepCard.hexToRgb(hexColor);
         return `rgba(${r}, ${g}, ${b}, ${this._alpha})`;
     }
 
@@ -75,7 +79,7 @@ class GoogleKeepCard extends LitElement {
         if (!Array.isArray(show) || !show.includes('unchecked') && !show.includes('checked')) {
             throw new Error("Missing configuration values for key: show");
         }
-        this._theme = config.theme || themeLight;
+        this._theme = config.theme || 'auto';
         this._alpha = config.alpha || 1;
         this._config = config;
     }
@@ -103,39 +107,191 @@ class GoogleKeepCard extends LitElement {
         const title = this._config.title ? html`<div class="card-header" style="padding: 8px 0 16px 0;"><div class="name">${this._config.title}</div></div>` : html``;
         const emptyScreen = notes.length ? html`` : html`<p style="text-align: center">No notes found!</p>`;
         return html`
-        <ha-card id="googleKeepCard" style="padding: 16px">
+        <ha-card id="googleKeepCard" style="padding: 16px" class="${this._theme == 'auto'? (this._hass.themes.darkMode ? 'dark' : 'light') : this._theme}">
             <style>
-              paper-checkbox {
-                pointer-events: none;
-                --paper-checkbox-label-color: ${this.getTextColor()};
-                --paper-checkbox-unchecked-color: ${this.getTextColor()};
-                --paper-checkbox-checkmark-color: ${this.getCheckedColor()};
-                --paper-checkbox-label-checked-color: ${this.getCheckedColor()};
-              }
-              div.noteBackground {
-                padding:10px;
-                border-radius:5px;
-                margin:5px;
-              }
-              p.noteTitle {
-                font-weight: bold;
-                margin: 0 0 10px 10px;
-                font-size: 120%;
-                color: ${this.getTextColor()};
-              }
-              p.noteTitle > a, p.noteTitle > a:visited, p.noteTitle > a:link {
-                color: ${this.getTextColor()};
-              }
-              p.noteBody {
-                margin: -3px;
-              }
-              div.noteLine {
-                margin: 3px;
-              }
-              hr {
-                margin: 10px 0;
-                border: 1px solid ${this.getTextColor()};
-              }
+                #googleKeepCard .card  {
+                    border: 1px solid transparent;
+                    border-radius: 8px;
+                    margin: 16px 0px;
+                    padding: 12px 16px;
+                }
+                
+                #googleKeepCard .noteTitle {
+                    font-weight: bold;
+                    margin: 0 0 14px 0;
+                    font-size: 120%;
+                }
+                
+                #googleKeepCard .noteLine  {
+                    margin-top: 6px;
+                    margin-bottom: 6px;
+                }
+                
+                #googleKeepCard hr {
+                    margin: 10px 0;
+                    border: 1px solid rgba(0,0,0,0.1);
+                }
+                
+                #googleKeepCard.dark {
+                    background-color: #202124;
+                }
+                #googleKeepCard.dark, #googleKeepCard.dark a, #googleKeepCard.dark a:visited, #googleKeepCard.dark a:link {
+                    color: #e8eaed;
+                }
+                
+                #googleKeepCard.dark .card.White {
+                    background-color: #202124;
+                    border-color: #5f6368;
+                }
+                #googleKeepCard.dark .card.Red {
+                    background-color: #5c2b29;
+                    border-color: #5c2b29;
+                }
+                #googleKeepCard.dark .card.Orange {
+                    background-color: #614a19;
+                    border-color: #614a19;
+                
+                }
+                #googleKeepCard.dark .card.Yellow {
+                    background-color: #635d19;
+                    border-color: #635d19;
+                }
+                #googleKeepCard.dark .card.Green {
+                    background-color: #345920;
+                    border-color: #345920;
+                }
+                #googleKeepCard.dark .card.Teal {
+                    background-color: #16504b;
+                    border-color: #16504b;
+                }
+                #googleKeepCard.dark .card.Blue {
+                    background-color: #2d555e;
+                    border-color: #2d555e;
+                }
+                #googleKeepCard.dark .card.DarkBlue {
+                    background-color: #1e3a5f;
+                    border-color: #1e3a5f;
+                }
+                #googleKeepCard.dark .card.Purple {
+                    background-color: #42275e;
+                    border-color: #42275e;
+                }
+                #googleKeepCard.dark .card.Pink {
+                    background-color: #5b2245;
+                    border-color: #5b2245;
+                }
+                #googleKeepCard.dark .card.Brown {
+                    background-color: #442f19;
+                    border-color: #442f19;
+                
+                }
+                #googleKeepCard.dark .card.Gray {
+                    background-color: #3c3f43;
+                    border-color: #3c3f43;
+                }
+                
+                #googleKeepCard.light {
+                    background-color: #fff;
+                }
+                
+                #googleKeepCard.light, #googleKeepCard.light a, #googleKeepCard.light a:visited, #googleKeepCard.light a:link {
+                    color: #202124;
+                }
+                #googleKeepCard.light .card.White {
+                    background-color: #fff;
+                    border-color: #e0e0e0;
+                }
+                #googleKeepCard.light .card.Red {
+                    background-color: #f28b82;
+                    border-color: #f28b82;
+                }
+                #googleKeepCard.light .card.Orange {
+                    background-color: #fbbc04;
+                    border-color: #fbbc04;
+                }
+                #googleKeepCard.light .card.Yellow {
+                    background-color: #fff475;
+                    border-color: #fff475;
+                }
+                #googleKeepCard.light .card.Green {
+                    background-color: #ccff90;
+                    border-color: #ccff90;
+                }
+                #googleKeepCard.light .card.Teal {
+                    background-color: #a7ffeb;
+                    border-color: #a7ffeb;
+                }
+                #googleKeepCard.light .card.Blue {
+                    background-color: #cbf0f8;
+                    border-color: #cbf0f8;
+                }
+                #googleKeepCard.light .card.DarkBlue {
+                    background-color: #aecbfa;
+                    border-color: #aecbfa;
+                }
+                #googleKeepCard.light .card.Purple {
+                    background-color: #d7aefb;
+                    border-color: #d7aefb;
+                }
+                #googleKeepCard.light .card.Pink {
+                    background-color: #fdcfe8;
+                    border-color: #fdcfe8;
+                }
+                #googleKeepCard.light .card.Brown {
+                    background-color: #e6c9a8;
+                    border-color: #e6c9a8;
+                }
+                #googleKeepCard.light .card.Gray {
+                    background-color: #e8eaed;
+                    border-color: #e8eaed;
+                }
+
+                #googleKeepCard .checked {
+                    color: #5f6368;
+                }
+                
+                #googleKeepCard .crossed {
+                    text-decoration: line-through;
+                }
+                
+                #googleKeepCard .checked.uncrossed {
+                    opacity: .35;
+                }
+                
+                #googleKeepCard .level-0 {
+                    margin-left: 24px;
+                }
+                #googleKeepCard .level-1 {
+                    margin-left: 44px;
+                }
+                #googleKeepCard .checked,  #googleKeepCard .unchecked {
+                    position: relative;
+                }
+                #googleKeepCard .checked::before,  #googleKeepCard .unchecked::before {
+                    content: '';
+                    width: 18px;
+                    height: 18px;
+                    position: absolute;
+                    left: -24px;
+                    opacity: 0.54;
+                    background-size: 18px 18px;
+                    background-position: center;
+                    background-repeat: no-repeat;
+                    
+                }
+                #googleKeepCard.dark .checked::before {
+                    background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSIjZmZmZmZmIj48cGF0aCBkPSJNMTkgM0g1Yy0xLjEgMC0yIC45LTIgMnYxNGMwIDEuMS45IDIgMiAyaDE0YzEuMSAwIDItLjkgMi0yVjVjMC0xLjEtLjktMi0yLTJ6bTAgMTZINVY1aDE0djE0eiIvPgogIDxwYXRoIGQ9Ik0xOCA5bC0xLjQtMS40LTYuNiA2LjYtMi42LTIuNkw2IDEzbDQgNHoiLz4KPC9zdmc+Cg==);
+                }
+                #googleKeepCard.dark .unchecked::before {
+                    background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSIjZmZmZmZmIj4KICA8cGF0aCBkPSJNMTkgNXYxNEg1VjVoMTRtMC0ySDVjLTEuMSAwLTIgLjktMiAydjE0YzAgMS4xLjkgMiAyIDJoMTRjMS4xIDAgMi0uOSAyLTJWNWMwLTEuMS0uOS0yLTItMnoiLz4KPC9zdmc+Cg==);
+                }
+                #googleKeepCard.light .checked::before {
+                    background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSIjMDAwIj48cGF0aCBkPSJNMTkgM0g1Yy0xLjEgMC0yIC45LTIgMnYxNGMwIDEuMS45IDIgMiAyaDE0YzEuMSAwIDItLjkgMi0yVjVjMC0xLjEtLjktMi0yLTJ6bTAgMTZINVY1aDE0djE0eiIvPgogIDxwYXRoIGQ9Ik0xOCA5bC0xLjQtMS40LTYuNiA2LjYtMi42LTIuNkw2IDEzbDQgNHoiLz4KPC9zdmc+Cg==);
+                }
+                #googleKeepCard.light .unchecked::before {
+                    background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSIjMDAwIj4KICA8cGF0aCBkPSJNMTkgNXYxNEg1VjVoMTRtMC0ySDVjLTEuMSAwLTIgLjktMiAydjE0YzAgMS4xLjkgMiAyIDJoMTRjMS4xIDAgMi0uOSAyLTJWNWMwLTEuMS0uOS0yLTItMnoiLz4KPC9zdmc+Cg==); 
+                }
+            
             </style>
             ${title}
             ${emptyScreen}
@@ -145,38 +301,54 @@ class GoogleKeepCard extends LitElement {
     }
 
     renderNote(note) {
-        return note.note_type === 'NodeType.List' ?
-            this.renderList(note) :
-            this.renderTextNote(note);
+        console.log(note.note_type, {note});
+        return html`
+<div class="card ${note['color']}">
+    <p class="noteTitle">${(typeof note['url']!= "undefined") ? html`<a target="_blank" href="${note['url']}">${note['title']}</a>` : html`${note['title']}` }</p>
+    ${note.note_type === 'NodeType.List' ? this.renderList(note) : this.renderTextNote(note)}
+</div>`
     }
 
     renderTextNote(note) {
         return html`
-<div class="noteBackground" style="background:${this.getColor(note['color'])};">
-    <p class="noteTitle">${(typeof note['url']!= "undefined") ? html`<a target="_blank" href="${note['url']}">${note['title']}</a>` : html`${note['title']}` }</p>
     <p class="noteBody">${note['lines'].map(line => this.renderLine(line))}</p>
-</div>`
+`
     }
 
     renderList(note) {
         const {show} = this._config;
         const showUnchecked = note['unchecked'].length && show.includes('unchecked');
         const showChecked = note['checked'].length && show.includes('checked');
+        console.log({result: this.renderList2(note), note});
         return html`
-<div class="noteBackground" style="background:${this.getColor(note['color'])};">
-    <p class="noteTitle">${(typeof note['url']!= "undefined") ? html`<a target="_blank" href="${note['url']}">${note['title']}</a>` : html`${note['title']}` }</p>
-    ${showUnchecked ? this.renderUncheckedList(note) : html``}
+    ${this.renderList2(note.children)}
     ${showUnchecked && showChecked ? html`<hr>` : html``}
-    ${showChecked ? this.renderCheckedList(note) : html``}
-</div>`
+    ${this.renderList2(note.children, true)}
+`
+    }
+
+    renderLine2(item, checked = false, level = 0) {
+        return html`<p class="noteLine ${checked? 'checked' : 'unchecked'} ${item.checked ? 'crossed' : 'uncrossed'} level-${level}">${item.text}</p>`;
+    }
+
+    renderList2(items, checked = false, level = 0) {
+        console.log(level, {items, checked, level});
+        if (!items?.length) {
+            return html``;
+        }
+        return html`${items?.filter(
+            c => checked ? (c.checked || c.children.some(cc => cc.checked)): !c.checked)
+        .map(
+            item => html`${this.renderLine2(item, checked, level)}${(item.children?.length ? this.renderList2(item.children, checked, level +1): '')}`
+        )}`;
     }
 
     renderUncheckedList(note) {
-        return html`<p class="noteBody">${note['unchecked'].map(line => this.renderLine(line))}</p>`;
+        return html`<p class="noteBody uncheck">${note['unchecked'].map(line => this.renderLine(line))}</p>`;
     }
 
     renderCheckedList(note) {
-        return html`<p class="noteBody">${note['children'].map(line => this.renderIfChecked(line))}</p>`;
+        return html`<p class="noteBody checked">${note['children'].map(line => this.renderIfChecked(line))}</p>`;
     }
 
     renderIfChecked(child) {

--- a/dist/google-keep-card.js
+++ b/dist/google-keep-card.js
@@ -41,6 +41,7 @@ class GoogleKeepCard extends LitElement {
         }
         this._theme = config.theme || 'auto';
         this._alpha = config.alpha || 1;
+        this._systemBox = !!config.systemBox;
         this._config = config;
     }
 
@@ -64,16 +65,36 @@ class GoogleKeepCard extends LitElement {
         if (!notes.length && this._config.hide_if_empty) {
             return html``;
         }
-        const title = this._config.title ? html`<div class="card-header" style="padding: 8px 0 16px 0;"><div class="name">${this._config.title}</div></div>` : html``;
+        const title = this._config.title && !this._systemBox ? html`<div class="card-header" style="padding: 8px 0 16px 0;"><div class="name">${this._config.title}</div></div>` : html``;
         const emptyScreen = notes.length ? html`` : html`<p style="text-align: center">No notes found!</p>`;
         return html`
-        <ha-card id="googleKeepCard" style="padding: 16px" class="${this._theme == 'auto'? (this._hass.themes.darkMode ? 'dark' : 'light') : this._theme}">
+        <ha-card id="googleKeepCard" class="${this._theme == 'auto'? (this._hass.themes.darkMode ? 'dark' : 'light') : this._theme} ${this._systemBox ? 'systemBox': ''}">
             <style>
+                #googleKeepCard {
+                    padding: 16px;
+                }
+                #googleKeepCard.systemBox {
+                    background-color: transparent !important;
+                    border: none;
+                    box-shadow: none;
+                    margin: 0px;
+                    padding: 0px;
+                }
+                    
                 #googleKeepCard .card  {
                     margin: 16px 0px;
                     padding: 12px 16px;
                     position: relative;
                 }
+                
+                #googleKeepCard.systemBox .card  {
+                    margin: var( --vertical-stack-card-margin, var(--stack-card-margin, 8px 0) );
+                }
+                #googleKeepCard.systemBox .card::before  {
+                    border-radius: var(--ha-card-border-radius, 4px);
+                    box-shadow: var( --ha-card-box-shadow, 0px 2px 1px -1px rgba(0, 0, 0, 0.2), 0px 1px 1px 0px rgba(0, 0, 0, 0.14), 0px 1px 3px 0px rgba(0, 0, 0, 0.12) );
+                }
+                    
                 #googleKeepCard .card:first-of-type {
                     margin-top: 0;
                 }

--- a/dist/google-keep-card.js
+++ b/dist/google-keep-card.js
@@ -18,7 +18,7 @@ class GoogleKeepCard extends LitElement {
     set hass(hass) {
         this._hass = hass;
     }
-    get hass(hass) {
+    get hass() {
         return this._hass;
     }
 


### PR DESCRIPTION
I add a new value "auto" for the theme setting. This will take the current HomeAssistant theme (I have a different theme across devices).
I also added an option systemBox to make it close to have multiple widget, by default this is false.
I also see that the theme doesn't truly match with the google one. I rewrite the code to copy the theme more closely.
The checkbox wasn't working on my setup, I guess it's a dependency issue. I simply rewrote that part using google keep svg inline the css.

I could adjust things or add options if required.